### PR TITLE
add requiremenets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow
+requests
+fut

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,11 @@ APP = ['FIFA 16 Auto Buyer.py']
 DATA_FILES = ['images','fonts','config']
 OPTIONS = {'argv_emulation': True, 'iconfile': './logo.icns'}
 
+with open('requirements.txt') as f:
+    requires = f.read().splitlines()
+
 setup(
+    install_requires=requires,
     app=APP,
     data_files=DATA_FILES,
     options={'py2app': OPTIONS},


### PR DESCRIPTION
Now it should download & install external packages before "compiling" script. Considering that You're making gui app, i'll recommend building "stable" versions on Your own for every platform (mac/win at least) and attach binaries (all python files attached) so not only geeks could launch it ;-).

https://github.com/oczkers/futgui/tree/installable_as_library
Here I've made same changes to allow installation as a library (setup.py install) but it probably won't work because only .py files are installed.
